### PR TITLE
Fix a syntax error

### DIFF
--- a/ruby_exercises/command-query/exercises/wallet_spec.rb
+++ b/ruby_exercises/command-query/exercises/wallet_spec.rb
@@ -80,3 +80,4 @@ RSpec.describe Wallet do
 
     expect(wallet.cents).to eq(1)
   end
+end


### PR DESCRIPTION
An `end` keyword was missing at the end of the file to close the `Rspec.describe Wallet do` code block.